### PR TITLE
Add Feature to Infer Implicit Relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,125 @@
-# dbml-relationalizer
+# @ymmy833y/dbml-relationalizer
+
+`@ymmy833y/dbml-relationalizer` is a CLI tool that generates **DBML (Database Markup Language)** representations of table relationships based on **database schema information** and **relationship definition files**.
+
+Key Features:
+- Automatically generate DBML by fetching schema information from an existing database  
+- Allow user-defined relationship additions through a `relations.yml` file  
+- Provide an inference feature that infers relationships from table and column names  
+
+
+## Installation
+
+```bash
+# Assuming it's published to the npm registry:
+npm install -g @ymmy833y/dbml-relationalizer
+
+# Or, clone the repository and install locally:
+git clone https://github.com/Ymmy833y/dbml-relationalizer.git
+cd dbml-relationalizer
+npm install
+npm run build
+npm link  # Global installation
+```
+
+After installation, you can use the `relation2dbml` command in your terminal/command line.
+
+---
+
+## Usage
+
+The basic usage is `relation2dbml <database-type> <connection> [options]`.  
+For example:
+```bash
+relation2dbml mysql "mysql://user:pass@localhost:3306/dbname" -o schema.dbml
+```
+
+This connects to the specified database, retrieves the schema information, and generates a DBML file.
+
+---
+
+## Options
+
+- `-o, --out-file <pathspec>`: Specify the output file path for the generated DBML. If omitted, the result is printed to stdout.  
+- `-v, --verbose`: Set log level to `debug` for more detailed logs.  
+- `-i, --input-file <pathspec>`: Specify the path to the relationship definition file (e.g., `relations.yml`). Defaults to `./relations.yml`.
+
+---
+
+## Inference Feature
+
+The **inference** feature looks at **primary keys (PK)** and **unique keys** to guess which tables and columns may be related, and generates inferred relationships in the DBML output.
+
+You can configure this in `relations.yml` like so:
+
+```yaml
+inference:
+  enabled: true
+  strategy: default  # 'default' (e.g., users.id), or 'identical' (e.g., users.user_id)
+```
+
+- `enabled`: Set to `true` to enable inference  
+- `strategy`:
+  - `default`: Uses `pluralize` to get the singular form of table names and looks for `<singularTableName>_<primaryKey>` columns
+  - `identical`: Assumes child columns share the same name as the parent column (e.g., parent `users.user_id` → child `%.id`)
+
+For instance, if the `users` table has a primary key `id`, the `default` strategy looks for child columns named `user_id`.
+
+---
+
+## Relationship Definition File (`relations.yml`)
+
+If you want to define custom relationships, create a `relations.yml` file with the following structure:
+
+```yaml
+inference:
+  enabled: true
+  strategy: default
+
+relations:
+  - parentQualifiedColumn: "users.id"
+    childQualifiedColumns:
+      - "orders.user_id"
+    ignoreChildQualifiedColumns:
+      - "some_other_table.user_id"
+  - parentQualifiedColumn: "products.id"
+    childQualifiedColumns:
+      - "orders.product_id"
+```
+
+### Fields Description
+
+- `parentQualifiedColumn`: `tableName.columnName` of the parent table  
+- `childQualifiedColumns`: A list of child columns to match (wildcard `%` is supported)  
+- `ignoreChildQualifiedColumns`: A list of columns to ignore. Useful for excluding certain automatically inferred relationships  
+
+Using this file, the tool will generate DBML relationships from both user-defined and inferred logic.
+
+---
+
+## Sample Commands
+
+### 1. No Inference, Only User-defined Relationships
+
+```bash
+# Example: Connect to MySQL, read relations.yml, and write the DBML to schema.dbml
+relation2dbml mysql "mysql://dbml:dbml@localhost:3309/dbml" \
+  -o schema.dbml -i relations.yml
+```
+
+If you want to disable inference, set `inference.enabled: false` in `relations.yml`.
+
+### 2. With Inference, Print to stdout
+
+```bash
+relation2dbml mysql "mysql://dbml:dbml@localhost:3309/dbml" \
+  -i relations.yml --verbose
+```
+
+In this example, if `inference.enabled: true` is present in `relations.yml`, the tool will infer relationships based on primary or unique keys. The `--verbose` flag will produce additional debug logs, and the final DBML is printed to stdout.
+
+---
+
+## License
+
+This tool is released under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/__tests__/src/commands/relation2dbml.test.ts
+++ b/__tests__/src/commands/relation2dbml.test.ts
@@ -1,59 +1,38 @@
 import { Command } from 'commander';
-import { loadRelationPattern, fetchSchema, findRelations, generate } from '../../../src/services/index';
-import { getVersion, getCommandOpt } from '../../../src/utils/utils';
-import logger from '../../../src/utils/logger';
-
 import generateDBML from '../../../src/commands/relation2dbml';
+import { loadRelationDefinitions, fetchSchema, generateInferredRelationPattern, findRelations, generate } from '../../../src/services/index';
+import logger from '../../../src/utils/logger';
+import { getVersion, getCommandOpt } from '../../../src/utils/utils';
+import { Relation } from '../../../src/types';
 
 jest.mock('../../../src/services/index');
-jest.mock('../../../src/utils/utils');
 jest.mock('../../../src/utils/logger');
+jest.mock('../../../src/utils/utils');
 
 describe('generateDBML', () => {
   const mockProgram = new Command();
+  const mockOptions = { inputFile: 'mockInputFile.yml', outFile: 'mockOutputFile.dbml' };
+  const mockRelationDefinitions = {
+    inference: { enabled: true, strategy: 'default' },
+    relations: [],
+  };
   const mockSchemaJson = {
-    tables: {
-      users: { name: 'users' },
-      orders: { name: 'orders' },
-    },
+    tables: { users: { name: 'users' }, orders: { name: 'orders' } },
     fields: {
       users: [{ name: 'id' }, { name: 'name' }],
       orders: [{ name: 'id' }, { name: 'user_id' }],
     },
     tableConstraints: {
-      users: { id: { pk: true } },
-      orders: { id: { pk: true }, user_id: { fk: true } },
+      users: { id: { pk: true }, email: { unique: true } },
+      orders: { id: { pk: true } },
     },
   };
   const mockSchemaMap = {
-    users: {
-      columns: ['id', 'name'],
-      primaryKeys: ['id'],
-    },
-    orders: {
-      columns: ['id', 'user_id'],
-      primaryKeys: ['id'],
-    },
+    users: { columns: ['id', 'name'], primaryKeys: ['id'], uniqueKeys: ['email'] },
+    orders: { columns: ['id', 'user_id'], primaryKeys: ['id'], uniqueKeys: [] },
   };
-  const mockRelations = [
-    {
-      parentTable: 'users',
-      parentColumn: 'id',
-      childTable: 'orders',
-      childColumn: 'user_id',
-    },
-  ];
-  const mockRelationPatterns = [
-    {
-      parentQualifiedColumn: 'users.id',
-      childQualifiedColumns: ['orders.user_id'],
-    },
-  ];
-  const mockOptions = {
-    inputFile: 'relations.yml',
-    outFile: 'output.dbml',
-    verbose: true,
-  };
+  const mockInferredRelations: Relation[] = [];
+  const mockRelations: Relation[] = [];
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -64,8 +43,9 @@ describe('generateDBML', () => {
       connection: 'postgres://user:password@localhost:5432/db',
       options: mockOptions,
     });
-    (loadRelationPattern as jest.Mock).mockReturnValue(mockRelationPatterns);
+    (loadRelationDefinitions as jest.Mock).mockReturnValue(mockRelationDefinitions);
     (fetchSchema as jest.Mock).mockResolvedValue(mockSchemaJson);
+    (generateInferredRelationPattern as jest.Mock).mockReturnValue(mockInferredRelations);
     (findRelations as jest.Mock).mockReturnValue(mockRelations);
   });
 
@@ -73,10 +53,12 @@ describe('generateDBML', () => {
     await generateDBML(mockProgram);
 
     expect(getVersion).toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith('Starting relation2dbml script (Version: 1.0.0)');
     expect(getCommandOpt).toHaveBeenCalledWith(mockProgram);
-    expect(loadRelationPattern).toHaveBeenCalledWith(mockOptions.inputFile);
+    expect(loadRelationDefinitions).toHaveBeenCalledWith(mockOptions.inputFile);
     expect(fetchSchema).toHaveBeenCalledWith('postgres', 'postgres://user:password@localhost:5432/db');
-    expect(findRelations).toHaveBeenCalledWith(mockSchemaMap, mockRelationPatterns);
+    expect(generateInferredRelationPattern).toHaveBeenCalledWith(mockSchemaMap, mockRelationDefinitions.inference);
+    expect(findRelations).toHaveBeenCalledWith(mockSchemaMap, mockRelationDefinitions, mockInferredRelations);
     expect(generate).toHaveBeenCalledWith(mockSchemaJson, mockRelations, mockOptions.outFile);
     expect(logger.info).toHaveBeenCalledWith('DBML generation completed successfully.');
   });

--- a/__tests__/src/services/inference.test.ts
+++ b/__tests__/src/services/inference.test.ts
@@ -1,0 +1,140 @@
+import pluralize from 'pluralize';
+import { DatabaseSchemaMap, InferenceDefinitions } from '../../../src/types';
+import logger from '../../../src/utils/logger';
+
+import { generateInferredRelationPattern } from '../../../src/services/inference';
+
+jest.mock('../../../src/utils/logger');
+jest.mock('pluralize');
+
+describe('generateInferredRelationPattern', () => {
+  const mockInferenceEnabled: InferenceDefinitions = {
+    enabled: true,
+  };
+
+  const mockInferenceDisabled: InferenceDefinitions = {
+    enabled: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (pluralize.singular as jest.Mock).mockImplementation((word) => word.slice(0, -1));
+  });
+
+  it('should generate inferred relation patterns with default strategy', () => {
+    const mockSchemaMap: DatabaseSchemaMap = {
+      users: {
+        columns: ['id', 'name', 'email'],
+        primaryKeys: ['id'],
+        uniqueKeys: ['email'],
+      },
+      orders: {
+        columns: ['id', 'user_id'],
+        primaryKeys: ['id'],
+        uniqueKeys: [],
+      },
+    };
+    const result = generateInferredRelationPattern(mockSchemaMap, mockInferenceEnabled);
+
+    expect(result).toEqual([
+      {
+        parentQualifiedColumn: 'users.id',
+        childQualifiedColumns: ['%.user_id'],
+      },
+      {
+        parentQualifiedColumn: 'users.email',
+        childQualifiedColumns: ['%.user_email'],
+      },
+      {
+        parentQualifiedColumn: 'orders.id',
+        childQualifiedColumns: ['%.order_id'],
+      },
+    ]);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Inferred Relation were generated successfully. Inferred Relation Pattern: ' +
+        JSON.stringify(result)
+    );
+  });
+
+  it('should generate inferred relation patterns with identical strategy', () => {
+    const mockSchemaMap: DatabaseSchemaMap = {
+      users: {
+        columns: ['user_id', 'name', 'email'],
+        primaryKeys: ['user_id'],
+        uniqueKeys: ['email'],
+      },
+      orders: {
+        columns: ['order_id', 'user_id'],
+        primaryKeys: ['order_id'],
+        uniqueKeys: [],
+      },
+    };
+    const identicalInference: InferenceDefinitions = {
+      enabled: true,
+      strategy: 'identical',
+    };
+
+    const result = generateInferredRelationPattern(mockSchemaMap, identicalInference);
+
+    expect(result).toEqual([
+      {
+        parentQualifiedColumn: 'users.user_id',
+        childQualifiedColumns: ['%.user_id'],
+      },
+      {
+        parentQualifiedColumn: 'users.email',
+        childQualifiedColumns: ['%.email'],
+      },
+      {
+        parentQualifiedColumn: 'orders.order_id',
+        childQualifiedColumns: ['%.order_id'],
+      },
+    ]);
+  });
+
+  it('should return an empty array if inference is disabled', () => {
+    const mockSchemaMap: DatabaseSchemaMap = {
+      users: {
+        columns: ['id', 'name', 'email'],
+        primaryKeys: ['id'],
+        uniqueKeys: ['email'],
+      },
+      orders: {
+        columns: ['id', 'user_id'],
+        primaryKeys: ['id'],
+        uniqueKeys: [],
+      },
+    };
+    const result = generateInferredRelationPattern(mockSchemaMap, mockInferenceDisabled);
+
+    expect(result).toEqual([]);
+    expect(logger.debug).toHaveBeenCalledWith('Implicit relationship inference is disabled.');
+  });
+
+  it('should handle a schema map with no primary or unique keys', () => {
+    const emptySchemaMap: DatabaseSchemaMap = {
+      empty_table: {
+        columns: ['id', 'name'],
+        primaryKeys: [],
+        uniqueKeys: [],
+      },
+    };
+
+    const result = generateInferredRelationPattern(emptySchemaMap, mockInferenceEnabled);
+
+    expect(result).toEqual([]);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Inferred Relation were generated successfully. Inferred Relation Pattern: []'
+    );
+  });
+
+  it('should handle empty schema map', () => {
+    const result = generateInferredRelationPattern({}, mockInferenceEnabled);
+
+    expect(result).toEqual([]);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Inferred Relation were generated successfully. Inferred Relation Pattern: []'
+    );
+  });
+});

--- a/__tests__/src/types.test.ts
+++ b/__tests__/src/types.test.ts
@@ -1,16 +1,75 @@
-import { isRelationPattern } from '../../src/types';
+import { isInferenceDefinitions, isRelationPattern } from '../../src/types';
 
-describe('isRelationPattern', () => {
-  it('should return true for a valid RelationPattern object', () => {
-    const validPattern = {
-      parentQualifiedColumn: 'users.id',
-      childQualifiedColumns: ['orders.user_id'],
+describe('isInferenceDefinitions', () => {
+  it('should return true for a valid InferenceDefinitions object', () => {
+    const validObject = {
+      enabled: true,
+      strategy: 'default',
     };
 
-    expect(isRelationPattern(validPattern)).toBe(true);
+    expect(isInferenceDefinitions(validObject)).toBe(true);
   });
 
-  it('should return true for a valid RelationPattern object with optional ignoreChildQualifiedColumns', () => {
+  it('should return true for a valid object without the optional strategy property', () => {
+    const validObjectWithoutStrategy = {
+      enabled: false,
+    };
+
+    expect(isInferenceDefinitions(validObjectWithoutStrategy)).toBe(true);
+  });
+
+  it('should return false if enabled is missing', () => {
+    const missingEnabled = {
+      strategy: 'default',
+    };
+
+    expect(isInferenceDefinitions(missingEnabled)).toBe(false);
+  });
+
+  it('should return false if enabled is not a boolean', () => {
+    const invalidEnabled = {
+      enabled: 'true',
+      strategy: 'default',
+    };
+
+    expect(isInferenceDefinitions(invalidEnabled)).toBe(false);
+  });
+
+  it('should return false if strategy is invalid', () => {
+    const invalidStrategy = {
+      enabled: true,
+      strategy: 'invalid',
+    };
+
+    expect(isInferenceDefinitions(invalidStrategy)).toBe(false);
+  });
+
+  it('should return false if there are additional properties', () => {
+    const extraProperties = {
+      enabled: true,
+      strategy: 'default',
+      extraKey: 'extraValue',
+    };
+
+    expect(isInferenceDefinitions(extraProperties)).toBe(false);
+  });
+
+  it('should return false for non-object inputs', () => {
+    expect(isInferenceDefinitions(null)).toBe(false);
+    expect(isInferenceDefinitions(undefined)).toBe(false);
+    expect(isInferenceDefinitions(123)).toBe(false);
+    expect(isInferenceDefinitions('string')).toBe(false);
+    expect(isInferenceDefinitions(['array'])).toBe(false);
+    expect(isInferenceDefinitions(true)).toBe(false);
+  });
+
+  it('should return false for an empty object', () => {
+    expect(isInferenceDefinitions({})).toBe(false);
+  });
+});
+
+describe('isRelationPattern', () => {
+  it('should return true for a valid RelationPattern object with optional childQualifiedColumns and ignoreChildQualifiedColumns', () => {
     const validPatternWithIgnore = {
       parentQualifiedColumn: 'users.id',
       childQualifiedColumns: ['orders.user_id'],
@@ -21,19 +80,9 @@ describe('isRelationPattern', () => {
   });
 
   it('should return false if parentQualifiedColumn is missing', () => {
-    const missingParentQualifiedColumn = {
-      childQualifiedColumns: ['orders.user_id'],
-    };
+    const missingParentQualifiedColumn = {};
 
     expect(isRelationPattern(missingParentQualifiedColumn)).toBe(false);
-  });
-
-  it('should return false if childQualifiedColumns is missing', () => {
-    const missingChildQualifiedColumns = {
-      parentQualifiedColumn: 'users.id',
-    };
-
-    expect(isRelationPattern(missingChildQualifiedColumns)).toBe(false);
   });
 
   it('should return false if parentQualifiedColumn is not a string', () => {
@@ -62,6 +111,29 @@ describe('isRelationPattern', () => {
     };
 
     expect(isRelationPattern(invalidIgnoreChildQualifiedColumns)).toBe(false);
+  });
+
+  it('should return false if both childQualifiedColumns and ignoreChildQualifiedColumns are undefined', () => {
+    const bothUndefined = {
+      parentQualifiedColumn: 'users.id',
+    };
+
+    expect(isRelationPattern(bothUndefined)).toBe(false);
+  });
+
+  it('should return true if one of childQualifiedColumns or ignoreChildQualifiedColumns is defined', () => {
+    const onlyChildDefined = {
+      parentQualifiedColumn: 'users.id',
+      childQualifiedColumns: ['orders.user_id'],
+    };
+
+    const onlyIgnoreDefined = {
+      parentQualifiedColumn: 'users.id',
+      ignoreChildQualifiedColumns: ['logs.user_id'],
+    };
+
+    expect(isRelationPattern(onlyChildDefined)).toBe(true);
+    expect(isRelationPattern(onlyIgnoreDefined)).toBe(true);
   });
 
   it('should return false for objects with additional properties', () => {

--- a/__tests__/src/utils/utils.test.ts
+++ b/__tests__/src/utils/utils.test.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import { Command } from 'commander';
 import logger from '../../../src/utils/logger';
 
-import { getVersion, getCommandOpt, splitQualifiedColumn, matchesWildcardPattern } from '../../../src/utils/utils';
+import { getVersion, getCommandOpt, splitQualifiedColumn, matchesWildcardPattern, addUniqueItems } from '../../../src/utils/utils';
 
 jest.mock('fs');
 jest.mock('path');
@@ -169,5 +169,75 @@ describe('matchesWildcardPattern', () => {
   it('should handle patterns without any wildcards', () => {
     expect(matchesWildcardPattern('exact_match', 'exact_match')).toBe(true);
     expect(matchesWildcardPattern('exact_match', 'different_match')).toBe(false);
+  });
+});
+
+describe('addUniqueItems', () => {
+  it('should add unique objects to the original list', () => {
+    const originalList = [
+      { key: 'value1', anotherKey: 'value2' },
+    ];
+    const itemsToAdd = [
+      { key: 'value1', anotherKey: 'value2' }, // duplicate object with different reference
+      { key: 'uniqueKey', anotherKey: 'uniqueValue' }, // unique object
+    ];
+
+    addUniqueItems(originalList, itemsToAdd);
+
+    expect(originalList).toEqual([
+      { key: 'value1', anotherKey: 'value2' },
+      { key: 'uniqueKey', anotherKey: 'uniqueValue' },
+    ]);
+  });
+
+  it('should not add duplicate objects with different references', () => {
+    const originalList = [
+      { key: 'value1', anotherKey: 'value2' },
+    ];
+    const duplicateObject = { key: 'value1', anotherKey: 'value2' }; // Same content, different reference
+
+    addUniqueItems(originalList, [duplicateObject]);
+
+    // Only the first object remains in the list
+    expect(originalList).toEqual([
+      { key: 'value1', anotherKey: 'value2' },
+    ]);
+  });
+
+  it('should handle an empty original list', () => {
+    const originalList: object[] = [];
+    const itemsToAdd = [
+      { key: 'value1', anotherKey: 'value2' },
+      { key: 'uniqueKey', anotherKey: 'uniqueValue' },
+    ];
+
+    addUniqueItems(originalList, itemsToAdd);
+
+    expect(originalList).toEqual([
+      { key: 'value1', anotherKey: 'value2' },
+      { key: 'uniqueKey', anotherKey: 'uniqueValue' },
+    ]);
+  });
+
+  it('should handle an empty itemsToAdd list', () => {
+    const originalList = [
+      { key: 'value1', anotherKey: 'value2' },
+    ];
+    const itemsToAdd: object[] = [];
+
+    addUniqueItems(originalList, itemsToAdd);
+
+    expect(originalList).toEqual([
+      { key: 'value1', anotherKey: 'value2' },
+    ]);
+  });
+
+  it('should handle empty original and itemsToAdd lists', () => {
+    const originalList: object[] = [];
+    const itemsToAdd: object[] = [];
+
+    addUniqueItems(originalList, itemsToAdd);
+
+    expect(originalList).toEqual([]);
   });
 });

--- a/__tests__/src/utils/validate.test.ts
+++ b/__tests__/src/utils/validate.test.ts
@@ -1,0 +1,135 @@
+import { isInferenceDefinitions, isRelationPattern } from '../../../src/types';
+import logger from '../../../src/utils/logger';
+
+import {
+  validateInferenceDefinitions,
+  validateRelationPatterns,
+  validateRelationPattern,
+} from '../../../src/utils/validate';
+
+jest.mock('../../../src/utils/logger');
+jest.mock('../../../src/types', () => ({
+  isInferenceDefinitions: jest.fn(),
+  isRelationPattern: jest.fn(),
+}));
+
+describe('validateInferenceDefinitions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return true for valid inference definitions', () => {
+    (isInferenceDefinitions as unknown as jest.Mock).mockReturnValue(true);
+
+    const validInference = {
+      enabled: true,
+      strategy: 'default',
+    };
+
+    const result = validateInferenceDefinitions(validInference);
+
+    expect(result).toBe(true);
+    expect(isInferenceDefinitions).toHaveBeenCalledWith(validInference);
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it('should return false for invalid inference definitions and log a debug message', () => {
+    (isInferenceDefinitions as unknown as jest.Mock).mockReturnValue(false);
+
+    const invalidInference = {
+      enabled: 'true',
+    };
+
+    const result = validateInferenceDefinitions(invalidInference);
+
+    expect(result).toBe(false);
+    expect(isInferenceDefinitions).toHaveBeenCalledWith(invalidInference);
+    expect(logger.debug).toHaveBeenCalledWith('Inference is invalid.');
+  });
+});
+
+describe('validateRelationPattern', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return true for a valid relation pattern', () => {
+    (isRelationPattern as unknown as jest.Mock).mockReturnValue(true);
+
+    const validRelation = {
+      parentQualifiedColumn: 'users.id',
+    };
+
+    const result = validateRelationPattern(validRelation, 0);
+
+    expect(result).toBe(true);
+    expect(isRelationPattern).toHaveBeenCalledWith(validRelation);
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it('should return false for an invalid relation pattern and log a debug message', () => {
+    (isRelationPattern as unknown as jest.Mock).mockReturnValue(false);
+
+    const invalidRelation = { parentQualifiedColumns: 'users' };
+
+    const result = validateRelationPattern(invalidRelation, 2);
+
+    expect(result).toBe(false);
+    expect(isRelationPattern).toHaveBeenCalledWith(invalidRelation);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Relation at index 3 is invalid. relation: {"parentQualifiedColumns":"users"}'
+    );
+  });
+});
+
+describe('validateRelationsPattern', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return true for an empty relations array', () => {
+    const result = validateRelationPatterns([]);
+    expect(result).toBe(true);
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it('should return true for a valid relations array', () => {
+    (isRelationPattern as unknown as jest.Mock).mockReturnValue(true);
+
+    const validRelations = [
+      { parentQualifiedColumn: 'users.id', childQualifiedColumns: ['orders.user_id'] },
+      { parentQualifiedColumn: 'products.id', childQualifiedColumns: ['sales.product_id'] },
+    ];
+
+    const result = validateRelationPatterns(validRelations);
+
+    expect(result).toBe(true);
+    expect(isRelationPattern).toHaveBeenCalledTimes(validRelations.length);
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it('should return false if any relation in the array is invalid', () => {
+    (isRelationPattern as unknown as jest.Mock).mockImplementation((relation) =>
+      relation.parentQualifiedColumn === 'users.id'
+    );
+
+    const mixedRelations = [
+      { parentQualifiedColumn: 'users.id' },
+      { parentQualifiedColumns: 'invalid' },
+    ];
+
+    const result = validateRelationPatterns(mixedRelations);
+
+    expect(result).toBe(false);
+    expect(isRelationPattern).toHaveBeenCalledTimes(mixedRelations.length);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Relation at index 2 is invalid. relation: {"parentQualifiedColumns":"invalid"}'
+    );
+  });
+
+  it('should return true if relations is undefined or not an array and log a debug message', () => {
+    const result = validateRelationPatterns(undefined);
+    expect(result).toBe(true);
+    expect(logger.debug).toHaveBeenCalledWith('Relations is not specified.');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@dbml/core": "^3.9.5",
     "commander": "^13.0.0",
     "dotenv": "^16.4.7",
+    "pluralize": "^8.0.0",
     "winston": "^3.17.0",
     "yaml": "^2.7.0"
   },
@@ -30,6 +31,7 @@
     "@types/commander": "^2.12.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^20.17.12",
+    "@types/pluralize": "^0.0.33",
     "@typescript-eslint/eslint-plugin": "^8.19.1",
     "@typescript-eslint/parser": "^8.19.1",
     "eslint": "^9.18.0",

--- a/relations.sample.yml
+++ b/relations.sample.yml
@@ -1,3 +1,7 @@
+inference:
+  enabled: true
+  strategy: default
+
 relations:
   - parentQualifiedColumn: "user.id"
     childQualifiedColumns:

--- a/src/services/import.ts
+++ b/src/services/import.ts
@@ -1,36 +1,28 @@
 import fs from 'fs';
 import { parse } from 'yaml';
-import { RelationPattern, isRelationPattern } from '../types.js';
+import { RelationDefinitions } from '../types.js';
+import { validateInferenceDefinitions, validateRelationPatterns } from '../utils/validate.js';
 import logger from '../utils/logger.js';
 
 const defaultFilePath = './relations.yml';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function validateRelationPattern(relation: any, index: number): boolean {
-  const isValid = isRelationPattern(relation);
-  if (!isValid) {
-    logger.debug(`Relation at index ${index+1} is invalid. relation: ${JSON.stringify(relation)}`);
-  }
-  return isValid;
-}
-
-function loadRelationPattern(filePath: string = defaultFilePath): RelationPattern[] {
+function loadRelationDefinitions(filePath: string = defaultFilePath): RelationDefinitions {
   logger.debug(`Starting to read the relation definition file at path: ${filePath}`);
 
   const fileContents = fs.readFileSync(filePath, 'utf8');
   const parsed = parse(fileContents);
   if (
     parsed &&
-    Array.isArray(parsed.relations) &&
-    parsed.relations.every(validateRelationPattern)
+    validateInferenceDefinitions(parsed.inference) &&
+    validateRelationPatterns(parsed.relations)
   ) {
-    logger.debug('All relations are valid.');
-    return parsed.relations as RelationPattern[];
+    logger.debug(`Relation definitions are valid. Relation definitions: ${JSON.stringify(parsed)}`);
+    return parsed as RelationDefinitions;
   } else {
     throw Error(`Invalid relation pattern format in ${filePath}.`);
   }
 };
 
 export {
-  loadRelationPattern
+  loadRelationDefinitions
 };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,5 @@
 export * from './connector.js';
 export * from './export.js';
 export * from './import.js';
+export * from './inference.js';
 export * from './relation.js';

--- a/src/services/inference.ts
+++ b/src/services/inference.ts
@@ -1,0 +1,65 @@
+import pluralize from 'pluralize';
+import { RelationPattern, InferenceDefinitions, InferenceStrategy, DatabaseSchemaMap } from '../types.js';
+import logger from '../utils/logger.js';
+
+/**
+ * Generates a qualified column pattern for child tables based on the inference strategy.
+ */
+function getChildQualifiedColumnPattern(
+  table: string,
+  primaryKey: string,
+  strategy: InferenceStrategy = 'default',
+): string {
+  if (strategy === 'identical') {
+    return `%.${primaryKey}`;
+  }
+  return `%.${pluralize.singular(table)}_${primaryKey}`;
+}
+
+/**
+ * Processes a list of keys (primary or unique) and generates inferred relation patterns.
+ */
+function processKeys(
+  table: string,
+  keys: string[],
+  inference: InferenceDefinitions,
+  inferredRelationPatterns: RelationPattern[]
+) {
+  keys.forEach(key => {
+    const childQualifiedColumns = getChildQualifiedColumnPattern(table, key, inference.strategy);
+
+    inferredRelationPatterns.push({
+      parentQualifiedColumn: `${table}.${key}`,
+      childQualifiedColumns: [childQualifiedColumns],
+    });
+  });
+}
+
+/**
+ * Generates inferred relation patterns between parent and child tables.
+ * @param schemaMap - The schema map of the database.
+ * @param inference - The inference definitions for generating patterns.
+ * @returns A list of inferred relation patterns.
+ */
+function generateInferredRelationPattern(
+  schemaMap: DatabaseSchemaMap,
+  inference: InferenceDefinitions
+): RelationPattern[] {
+  if (!inference.enabled) {
+    logger.debug('Implicit relationship inference is disabled.');
+    return [];
+  }
+
+  const inferredRelationPatterns: RelationPattern[] = [];
+  for (const [table, tableSchema] of Object.entries(schemaMap)) {
+    processKeys(table, tableSchema.primaryKeys, inference, inferredRelationPatterns);
+    processKeys(table, tableSchema.uniqueKeys, inference, inferredRelationPatterns);
+  }
+
+  logger.debug(`Inferred Relation were generated successfully. Inferred Relation Pattern: ${JSON.stringify(inferredRelationPatterns)}`);
+  return inferredRelationPatterns;
+}
+
+export {
+  generateInferredRelationPattern
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,21 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+type InferenceStrategy = 'default' | 'identical';
+
+interface InferenceDefinitions {
+  enabled: boolean;
+  strategy?: InferenceStrategy;
+}
+
 interface RelationPattern {
   parentQualifiedColumn: string;
-  childQualifiedColumns: string[];
+  childQualifiedColumns?: string[];
   ignoreChildQualifiedColumns?: string[];
+}
+
+interface RelationDefinitions {
+  inference: InferenceDefinitions;
+  relations?: RelationPattern[];
 }
 
 interface Relation {
@@ -22,6 +34,7 @@ interface DatabaseSchemaJson {
 interface TableSchema {
   columns: string[];
   primaryKeys: string[];
+  uniqueKeys: string[];
 }
 
 type DatabaseSchemaMap = Record<string, TableSchema>;
@@ -32,13 +45,13 @@ interface CommandOptions {
   verbose?: boolean;
 }
 
-function isRelationPattern(obj: any): obj is RelationPattern {
-  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+function isInferenceDefinitions(obj: any): obj is InferenceDefinitions {
+  if (typeof obj !== 'object' || obj === null) {
     return false;
   }
 
-  const requiredKeys = ['parentQualifiedColumn', 'childQualifiedColumns'];
-  const optionalKeys = ['ignoreChildQualifiedColumns'];
+  const requiredKeys = ['enabled'];
+  const optionalKeys = ['strategy'];
   const allowedKeys = [...requiredKeys, ...optionalKeys];
 
   const objKeys = Object.keys(obj);
@@ -55,17 +68,57 @@ function isRelationPattern(obj: any): obj is RelationPattern {
 
   // Check the properties type
   return (
+    typeof obj.enabled === 'boolean' &&
+    (obj.strategy === undefined || ['default', 'identical'].includes(obj.strategy))
+  );
+}
+
+function isRelationPattern(obj: any): obj is RelationPattern {
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
+  }
+
+  const requiredKeys = ['parentQualifiedColumn'];
+  const optionalKeys = ['childQualifiedColumns', 'ignoreChildQualifiedColumns'];
+  const allowedKeys = [...requiredKeys, ...optionalKeys];
+
+  const objKeys = Object.keys(obj);
+
+  // Required properties are present
+  if (!requiredKeys.every(key => objKeys.includes(key))) {
+    return false;
+  }
+
+  // Disallowed properties are not present
+  if (!objKeys.every(key => allowedKeys.includes(key))) {
+    return false;
+  }
+
+  // Ensure at least one of 'childQualifiedColumns' or 'ignoreChildQualifiedColumns' is defined
+  if (
+    obj.childQualifiedColumns === undefined &&
+    obj.ignoreChildQualifiedColumns === undefined
+  ) {
+    return false;
+  }
+
+  // Check the properties type
+  return (
     typeof obj.parentQualifiedColumn === 'string' &&
-    Array.isArray(obj.childQualifiedColumns) &&
+    (obj.childQualifiedColumns === undefined || Array.isArray(obj.childQualifiedColumns)) &&
     (obj.ignoreChildQualifiedColumns === undefined || Array.isArray(obj.ignoreChildQualifiedColumns))
   );
 }
 
 export {
+  InferenceStrategy,
+  InferenceDefinitions,
   RelationPattern,
+  RelationDefinitions,
   Relation,
   DatabaseSchemaJson,
   DatabaseSchemaMap,
   CommandOptions,
+  isInferenceDefinitions,
   isRelationPattern
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -72,9 +72,33 @@ function matchesWildcardPattern(value: string, pattern: string): boolean {
   return regexCache[pattern].test(value);
 }
 
+/**
+ * Add new elements to the original list while eliminating duplicates
+ * @param originalList
+ * @param itemsToAdd
+ * @param keyFn generates a unique key for each element (optional)
+ */
+function addUniqueItems<T>(
+  originalList: T[],
+  itemsToAdd: T[],
+  keyFn?: (item: T) => string
+): void {
+  const generateKey = keyFn || ((item: T) => JSON.stringify(item));
+  const itemSet = new Set<string>(originalList.map(generateKey));
+
+  itemsToAdd.forEach(item => {
+    const key = generateKey(item);
+    if (!itemSet.has(key)) {
+      itemSet.add(key);
+      originalList.push(item);
+    }
+  });
+}
+
 export {
   getVersion,
   getCommandOpt,
   splitQualifiedColumn,
-  matchesWildcardPattern
+  matchesWildcardPattern,
+  addUniqueItems
 };

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,0 +1,35 @@
+import { isInferenceDefinitions, isRelationPattern } from '../types.js';
+import logger from '../utils/logger.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function validateInferenceDefinitions(inference: any): boolean {
+  const isValid = isInferenceDefinitions(inference);
+  if (!isValid) {
+    logger.debug('Inference is invalid.');
+  }
+  return isValid;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function validateRelationPattern(relation: any, index: number): boolean {
+  const isValid = isRelationPattern(relation);
+  if (!isValid) {
+    logger.debug(`Relation at index ${index+1} is invalid. relation: ${JSON.stringify(relation)}`);
+  }
+  return isValid;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function validateRelationPatterns(relations: any): boolean {
+  if (!relations || !Array.isArray(relations)) {
+    logger.debug('Relations is not specified.')
+    return true;
+  }
+  return relations.every(validateRelationPattern);
+}
+
+export {
+  validateInferenceDefinitions,
+  validateRelationPatterns,
+  validateRelationPattern
+};


### PR DESCRIPTION
A new feature allows implicit relationships to be inferred from `relation.yml` when `inference.enabled: true` is set. The system examines primary keys (PK) and unique keys (UK) to determine potential relationships and includes them in the DBML output.

Configuration Highlights:
- **`enabled`**: Activates the inference feature.
- **`strategy`**:
  - **`default`**: Infers relationships using singular table names and `<singularTableName>_<primaryKey>` columns.
  - **`identical`**: Matches child columns with the exact names of parent columns.

This feature automates the detection of relationships, streamlining schema design.