### PR TITLE
Add npm registry configuration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "author": "Ymmy833y",
   "license": "MIT",
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
   "bugs": {


### PR DESCRIPTION
Added "registry": "https://registry.npmjs.org/" to package.json to ensure consistent package management by explicitly defining the npm registry URL.
